### PR TITLE
add styles to tables addresses #2

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,6 +33,8 @@
 <script>
 window.onload = function() {
   init()
+  //todo: add custom styles to style.css
+  $('table').addClass('table table-striped');
 };
 
 var dataURL = '{{page.data}}';


### PR DESCRIPTION
This is a very minor change to add .table class to tables to give us access to bootstrap default styling. Beyond that we can add some custom styles (color for example) and maybe eventually swap in CSS instead of the hacky solution of adding the class via jQuery.
