### PR TITLE
Bb scrollspy fix

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,6 +37,7 @@ window.onload = function() {
   $('#organizations').before($('#viz-wrapper'));
   {% if page.layout == 'policy' %}
   buildTOC();
+  $('.nav.toc').append('<li><a href="#">Back to Top</a></li>');
   var vizData = browserData[$('.data-browser-select').val()];
   loadViz(vizData);
   $('.data-browser-select').change(function(){

--- a/_layouts/policy.html
+++ b/_layouts/policy.html
@@ -13,7 +13,7 @@
 
 <body>
   {% include header.html %}
-  <main role="main" style="position: relative">
+  <main role="main">
     <div class="container-fluid masthead policies">
       <div class="darkener"></div>
       <div class="container">
@@ -63,8 +63,6 @@
           <!-- Add post -->
           <a href="//prose.io/#jasonlally/housing-policy-hub/new/gh-pages/_posts" target="_blank">Add a post with Prose.io</a>
           </div>
-          <!-- <h2 id="">Back to Top</h2> -->
-
         </div>
         <div class="col-sm-4">
           <aside class="nav-toc" data-spy="affix" data-offset-top="200" role="complementary">

--- a/_layouts/policy.html
+++ b/_layouts/policy.html
@@ -63,7 +63,7 @@
           <!-- Add post -->
           <a href="//prose.io/#jasonlally/housing-policy-hub/new/gh-pages/_posts" target="_blank">Add a post with Prose.io</a>
           </div>
-          <h2 id="">Back to Top</h2>
+          <!-- <h2 id="">Back to Top</h2> -->
 
         </div>
         <div class="col-sm-4">

--- a/_layouts/policy.html
+++ b/_layouts/policy.html
@@ -13,7 +13,7 @@
 
 <body>
   {% include header.html %}
-  <main role="main">
+  <main role="main" style="position: relative">
     <div class="container-fluid masthead policies">
       <div class="darkener"></div>
       <div class="container">
@@ -27,7 +27,7 @@
       <div class="row">
         <div class="col-sm-8">
           <article role="article">
-            <h2 id="summary" class="sr-only">Summary</h2>
+            <!-- <h2 id="summary" class="sr-only">Summary</h2> -->
             <p class="lead">{{ page.summary }}</p>
             <h2 id="description">Description</h2>
             {{ content }}
@@ -54,6 +54,7 @@
                 <div class="notes"></div>
               </div>
             </div>
+
           </article>
           <div id="edit-links">
            <!-- Edit current page -->
@@ -62,6 +63,8 @@
           <!-- Add post -->
           <a href="//prose.io/#jasonlally/housing-policy-hub/new/gh-pages/_posts" target="_blank">Add a post with Prose.io</a>
           </div>
+          <h2 id="">Back to Top</h2>
+
         </div>
         <div class="col-sm-4">
           <aside class="nav-toc" data-spy="affix" data-offset-top="200" role="complementary">


### PR DESCRIPTION
Removed the summary h2 element which was causing the scrollspy issues as a result of having the sr-only class (made the h2 all tiny and oddly positioned for scrollspy, so it had issues identifying it).

I also added a Back to Top to the right side nav menu.
